### PR TITLE
Set images per_page to 200 to reduce requests

### DIFF
--- a/src/build/get.js
+++ b/src/build/get.js
@@ -45,7 +45,7 @@ const main = async () => {
     }
 
     const results = [];
-    let nextPage = `https://api.digitalocean.com/v2/images?page=1&type=${process.env.IMAGE_TYPE}`;
+    let nextPage = `https://api.digitalocean.com/v2/images?page=1&per_page=200&type=${process.env.IMAGE_TYPE}`;
     while (nextPage) {
         const data = await get(nextPage);
         results.push(...data.images);


### PR DESCRIPTION
## Type of Change

- **Build Scripts:** Image fetching

## What issue does this relate to?

https://github.com/do-community/available-images/actions/runs/3895182601 / https://github.com/do-community/available-images/actions/runs/3895182598

### What should this PR do?

We were fetching images using the default `per_page` value which is `20`. We can set this to a maximum of `200`, drastically reducing the number of requests the script makes to fetch all the available images.

### What are the acceptance criteria?

Tool builds as expected, with all images listed in the tool still.