### PR TITLE
Fix continual pushes for GH Pages, remove report

### DIFF
--- a/.github/workflows/gh-pages-workflow.yml
+++ b/.github/workflows/gh-pages-workflow.yml
@@ -37,6 +37,9 @@ jobs:
       env:
         DIGITALOCEAN_TOKEN: ${{ secrets.DIGITALOCEAN_TOKEN }}
 
+    - name: Clean build output
+      run: rm dist/report.html
+
     - name: Deploy master to GitHub Pages
       uses: JamesIves/github-pages-deploy-action@v4
       with:


### PR DESCRIPTION
## Type of Change

- **Build Scripts:** GitHub Pages workflow

## What issue does this relate to?

N/A

### What should this PR do?

Comparing the last two hashes pushed to GitHub Pages, the only difference was the report:

```
git --no-pager diff --no-index --unified=0 ~/Downloads/available-images-171be76020d51ad5def5df981ae0fd47df1ff1bb ~/Downloads/available-images-dacb17c8642d2c38a5718f1ffd86b694bca6e2f0 
diff --git a/Users/mattcowley/Downloads/available-images-171be76020d51ad5def5df981ae0fd47df1ff1bb/report.html b/Users/mattcowley/Downloads/available-images-dacb17c8642d2c38a5718f1ffd86b694bca6e2f0/report.html
index c7a927f..29a9461 100644
--- a/Users/mattcowley/Downloads/available-images-171be76020d51ad5def5df981ae0fd47df1ff1bb/report.html
+++ b/Users/mattcowley/Downloads/available-images-dacb17c8642d2c38a5718f1ffd86b694bca6e2f0/report.html
@@ -6 +6 @@
-    <title>available-images [14 May 2023 at 15:09]</title>
+    <title>available-images [13 May 2023 at 15:08]</title>
```

We don't actually need that report in the GitHub Pages output at all, and it is causing us to push every single run, rather than only when the output actually changes. This PR removes the report from the output so that we don't continually push to pages.

### What are the acceptance criteria?

Report removed from GitHub Pages output.
